### PR TITLE
feat: Add --timeout option to CLI

### DIFF
--- a/src/md-to-notion-cli.ts
+++ b/src/md-to-notion-cli.ts
@@ -25,6 +25,7 @@ async function main(
     useGithubLinkReplacer: string
     delete: boolean
     renew: boolean
+    timeout: number
   }
 ) {
   let replacer
@@ -57,7 +58,8 @@ async function main(
   }
 
   if (dir) {
-    const notion = new Client({ auth: options.token })
+    const timeoutMs = parseInt(String(options.timeout), 10)
+    const notion = new Client({ auth: options.token, timeoutMs })
     if (options.renew) {
       await archiveChildPages(notion, options.pageId)
     }
@@ -108,6 +110,12 @@ program
     false
   )
   .option("-n, --renew", "Delete all pages in Notion before sync", false)
+  .option("--timeout <number>", "Timeout for API calls in milliseconds", "10000")
   .action(main)
 
-program.parse(process.argv)
+// Export for testing purposes
+export { program, main }
+
+if (require.main === module) {
+  program.parse(process.argv)
+}

--- a/temp_md_files_manual_test/test.md
+++ b/temp_md_files_manual_test/test.md
@@ -1,0 +1,1 @@
+# Test File for Manual Timeout Test

--- a/test/md-to-notion-cli.test.ts
+++ b/test/md-to-notion-cli.test.ts
@@ -1,0 +1,99 @@
+jest.mock("@notionhq/client") // Ensure this is at the very top
+
+import { Client } from "@notionhq/client" // Import type, actual is mocked
+import { Command } from "commander"
+
+// Type alias for the mocked client, will be assigned in beforeEach
+let MockedClient: jest.MockedClass<typeof Client>
+
+// Mock 'readMarkdownFiles' and other functions to avoid side effects
+// These mocks are hoisted by Jest, so they apply to any subsequent require
+jest.mock("../src/index", () => ({
+  ...jest.requireActual("../src/index"),
+  readMarkdownFiles: jest.fn().mockReturnValue({ name: "mockDir", files: [], subfolders: [] }),
+  syncToNotion: jest.fn().mockResolvedValue(undefined),
+  printFolderHierarchy: jest.fn(),
+}))
+
+jest.mock("../src/sync-to-notion", () => ({
+  collectCurrentFiles: jest.fn().mockResolvedValue(new Map()),
+  archiveChildPages: jest.fn().mockResolvedValue(undefined),
+}))
+
+describe("md-to-notion-cli", () => {
+  let program: Command
+  let originalArgv: string[]
+  let consoleLogSpy: jest.SpyInstance
+  let consoleErrorSpy: jest.SpyInstance
+  let processExitSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    jest.resetModules() // Reset modules first
+
+    // Now require the mocked Client and the program
+    MockedClient = require("@notionhq/client").Client as jest.MockedClass<typeof Client>
+    program = require("../src/md-to-notion-cli").program
+
+    // Clear mocks for each test
+    MockedClient.mockClear()
+    // jest.clearAllMocks() // This might be too broad if other mocks are needed across tests in a suite
+
+    originalArgv = [...process.argv]
+    process.argv = ["node", "md-to-notion-cli.js", "mockDir"] 
+
+    consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => {})
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {})
+    processExitSpy = jest.spyOn(process, "exit").mockImplementation((() => {}) as (code?: string | number | null | undefined) => never)
+  })
+
+  afterEach(() => {
+    process.argv = originalArgv
+    consoleLogSpy.mockRestore()
+    consoleErrorSpy.mockRestore()
+    processExitSpy.mockRestore()
+  })
+
+  it("should call Notion Client with default timeout (10000ms) when --timeout is not provided", async () => {
+    const testArgs = ["node", "md-to-notion-cli.js", "mockDir", "--token", "test-token", "--page-id", "test-page-id"]
+    await program.parseAsync(testArgs, { from: "user" })
+
+    expect(MockedClient).toHaveBeenCalledTimes(1)
+    expect(MockedClient).toHaveBeenCalledWith({
+      auth: "test-token",
+      timeoutMs: 10000, 
+    })
+  })
+
+  it("should call Notion Client with specified timeout when --timeout is provided", async () => {
+    const testArgs = ["node", "md-to-notion-cli.js", "mockDir", "--token", "test-token", "--page-id", "test-page-id", "--timeout", "5000"]
+    await program.parseAsync(testArgs, { from: "user" })
+
+    expect(MockedClient).toHaveBeenCalledTimes(1)
+    expect(MockedClient).toHaveBeenCalledWith({
+      auth: "test-token",
+      timeoutMs: 5000,
+    })
+  })
+
+  it("should call Notion Client with 1ms timeout when --timeout 1 is provided", async () => {
+    const testArgs = ["node", "md-to-notion-cli.js", "mockDir", "--token", "test-token", "--page-id", "test-page-id", "--timeout", "1"]
+    await program.parseAsync(testArgs, { from: "user" })
+
+    expect(MockedClient).toHaveBeenCalledTimes(1)
+    expect(MockedClient).toHaveBeenCalledWith({
+      auth: "test-token",
+      timeoutMs: 1,
+    })
+  })
+
+  it("should parse timeout as an integer", async () => {
+    const testArgs = ["node", "md-to-notion-cli.js", "mockDir", "--token", "test-token", "--page-id", "test-page-id", "--timeout", "123.45"]
+    await program.parseAsync(testArgs, { from: "user" })
+
+    expect(MockedClient).toHaveBeenCalledTimes(1)
+    expect(MockedClient).toHaveBeenCalledWith({
+      auth: "test-token",
+      timeoutMs: 123, 
+    })
+  })
+})


### PR DESCRIPTION
This commit introduces a `--timeout` option to the `md-to-notion-cli.ts` script.

The timeout is applied when calling the Notion API. The default timeout is 10 seconds (10000ms).

Changes include:
- Added a `--timeout` option to the commander program definition in `src/md-to-notion-cli.ts`.
- Updated the `main` function to accept and parse the `timeout` option.
- Passed the parsed timeout value to the `timeoutMs` parameter of the Notion `Client` constructor.
- Added unit tests in `test/md-to-notion-cli.test.ts` to verify:
    - Default timeout is applied.
    - Custom timeout values are correctly passed.
    - Timeout value is parsed as an integer.
- Manually tested the CLI with various timeout values to confirm expected behavior, including successful calls (with invalid token) and timeout errors with very short timeout values.