### PR TITLE
Fix error on syncing file with deeply nested numbered list

### DIFF
--- a/src/sync-to-notion.ts
+++ b/src/sync-to-notion.ts
@@ -157,6 +157,10 @@ export async function syncToNotion(
             children[index] = block.bulleted_list_item?.children
             delete block.bulleted_list_item?.children
           }
+          if (limitChild && block.numbered_list_item?.children) {
+            children[index] = block.numbered_list_item?.children
+            delete block.numbered_list_item?.children
+          }
           return block
         })
       try {

--- a/src/sync-to-notion.ts
+++ b/src/sync-to-notion.ts
@@ -153,13 +153,9 @@ export async function syncToNotion(
       const chunk = blocks
         .slice(i, i + NOTION_BLOCK_LIMIT)
         .map((block, index) => {
-          if (limitChild && block.bulleted_list_item?.children) {
-            children[index] = block.bulleted_list_item?.children
-            delete block.bulleted_list_item?.children
-          }
-          if (limitChild && block.numbered_list_item?.children) {
-            children[index] = block.numbered_list_item?.children
-            delete block.numbered_list_item?.children
+          if (limitChild && block[block.type]?.children) {
+            children[index] = block[block.type]?.children
+            delete block[block.type]?.children
           }
           return block
         })

--- a/test/sync-to-notion.test.ts
+++ b/test/sync-to-notion.test.ts
@@ -379,6 +379,145 @@ describe("syncToNotion", () => {
     expect(linkMap.get(`./test-file`)?.id).toBe("test-file")
   })
 
+  it("creates a new page with deeply nested numbered list", async () => {
+    const pageId = "test-page-id"
+    const linkMap = new Map<string, NotionPageLink>()
+    const folder: Folder = {
+      name: "root",
+      files: [
+        {
+          fileName: "test-file",
+          getContent: _ => [
+            {
+              numbered_list_item: {
+                children: [
+                  {
+                    bulleted_list_item: {
+                      children: [
+                        {
+                          numbered_list_item: {
+                            children: [
+                              {
+                                bulleted_list_item: {
+                                  children: [
+                                    {
+                                      numbered_list_item: {
+                                        rich_text: [
+                                          {
+                                            annotations: {
+                                              bold: false,
+                                              code: false,
+                                              color: "default",
+                                              italic: false,
+                                              strikethrough: false,
+                                              underline: false,
+                                            },
+                                            text: {
+                                              content: "depth5",
+                                            },
+                                            type: "text",
+                                          },
+                                        ],
+                                      },
+                                      object: "block",
+                                      type: "numbered_list_item",
+                                    },
+                                  ],
+                                  rich_text: [
+                                    {
+                                      annotations: {
+                                        bold: false,
+                                        code: false,
+                                        color: "default",
+                                        italic: false,
+                                        strikethrough: false,
+                                        underline: false,
+                                      },
+                                      text: {
+                                        content: "depth4",
+                                      },
+                                      type: "text",
+                                    },
+                                  ],
+                                },
+                                object: "block",
+                                type: "bullet_list_item",
+                              },
+                            ],
+                            rich_text: [
+                              {
+                                annotations: {
+                                  bold: false,
+                                  code: false,
+                                  color: "default",
+                                  italic: false,
+                                  strikethrough: false,
+                                  underline: false,
+                                },
+                                text: {
+                                  content: "depth3",
+                                },
+                                type: "text",
+                              },
+                            ],
+                          },
+                          object: "block",
+                          type: "numbered_list_item",
+                        },
+                      ],
+                      rich_text: [
+                        {
+                          annotations: {
+                            bold: false,
+                            code: false,
+                            color: "default",
+                            italic: false,
+                            strikethrough: false,
+                            underline: false,
+                          },
+                          text: {
+                            content: "depth2",
+                          },
+                          type: "text",
+                        },
+                      ],
+                    },
+                    object: "block",
+                    type: "bulleted_list_item",
+                  },
+                ],
+                rich_text: [
+                  {
+                    annotations: {
+                      bold: false,
+                      code: false,
+                      color: "default",
+                      italic: false,
+                      strikethrough: false,
+                      underline: false,
+                    },
+                    text: {
+                      content: "depth1",
+                    },
+                    type: "text",
+                  },
+                ],
+              },
+              object: "block",
+              type: "numbered_list_item",
+            },
+          ],
+        },
+      ],
+      subfolders: [],
+    }
+
+    await syncToNotion(mockNotionClient, pageId, folder, linkMap)
+
+    expect(linkMap.size).toBe(1)
+    expect(linkMap.get(`./test-file`)?.id).toBe("test-file")
+  })
+
   it("updates an existing page for a markdown file", async () => {
     const pageId = "test-page-id"
     const linkMap = new Map<string, NotionPageLink>([


### PR DESCRIPTION
The error is basically the same as https://github.com/vrerv/md-to-notion/issues/6 but for numbered lists.

Currently `appendBlockInChunks` only looks at `block.bulleted_list_item?.children` to determine whether to set aside the current block's children to be appended in a separate loop.

This PR changes the check to look at `block[block.type]?.children` instead.

`findMaxDepth` also looks at `block[block.type]` to recurse into the node tree, so I figured using `block.type` this way would be fine.

https://github.com/vrerv/md-to-notion/blob/cb826873e7a4c94b9658dd2b08139e8c86104ec5/src/sync-to-notion.ts#L79